### PR TITLE
Fix the GoL bug

### DIFF
--- a/src/conway.rs
+++ b/src/conway.rs
@@ -12,6 +12,8 @@ mod organism;
 
 pub use error::GameError;
 pub use grid::Grid;
+pub use grid::SubgridValuesIter;
+pub use grid::{GRID_HEIGHT, GRID_WIDTH, NUMBER_OF_SUBGRIDS};
 pub use index::Index;
 
 pub type Result<V> = std::result::Result<V, GameError>;
@@ -120,6 +122,17 @@ impl Conway {
             .toggle();
         Ok(())
     }
+
+    /// Returns vector of iterators. This should allow us to create a bit more complicated patterns
+    /// with the sounds, not just from right to left. But something like a cascade between the
+    /// subsequent grids or something similar
+    // Let's hope, lifetimes will not kill us here
+    pub fn get_pitch_and_volume_per_subgrids(&mut self) -> Vec<SubgridValuesIter> {
+        self.grids
+            .iter_mut()
+            .map(Grid::get_pitch_and_volume_per_subgrid)
+            .collect()
+    }
 }
 
 #[cfg(test)]
@@ -173,5 +186,30 @@ mod test {
             .iter()
             .zip(old_games.iter())
             .any(|(new, old)| old == new));
+    }
+
+    #[test]
+    fn test_pitch_and_volume() {
+        let mut games = Conway::start_with_capacity(10);
+
+        games.next_gen();
+        let number_of_games = games.grids.len();
+        let mut pitches_and_volumes = games.get_pitch_and_volume_per_subgrids();
+        let mut finished_grid_counter: usize = 0;
+
+        for i in 0..number_of_games * NUMBER_OF_SUBGRIDS {
+            let upper_bound: usize = (i + 1).min(number_of_games);
+            for grid_idx in finished_grid_counter..upper_bound {
+                match pitches_and_volumes[grid_idx].next() {
+                    Some((pitch, volume)) => {
+                        println!("({},{}), grid: {}", pitch, volume, grid_idx);
+                    }
+                    None => {
+                        finished_grid_counter += 1;
+                    }
+                }
+            }
+        }
+        assert!(false);
     }
 }

--- a/src/conway/grid.rs
+++ b/src/conway/grid.rs
@@ -38,11 +38,12 @@ impl Grid {
 
     pub fn random() -> Grid {
         let mut rng = thread_rng();
-        let mut cells: [Cell; GRID_WIDTH * GRID_HEIGHT] = [true.into(); GRID_WIDTH * GRID_HEIGHT];
+        let mut cells: [Cell; GRID_WIDTH * GRID_HEIGHT] = [false.into(); GRID_WIDTH * GRID_HEIGHT];
 
-        cells
-            .iter_mut()
-            .for_each(|cell| *cell = rng.gen_bool(1.2 / 3.0).into());
+        cells.iter_mut().for_each(|cell| {
+            let value = rng.gen_bool(1.2 / 3.0).into();
+            *cell = value;
+        });
 
         Self {
             cells,
@@ -53,20 +54,20 @@ impl Grid {
         }
     }
 
-    pub fn next_gen(&mut self) -> usize {
+    pub fn next_gen(&mut self) {
         if self.stopped {
-            return 0;
+            return;
         }
 
-        let mut death_counter: usize = 0;
         let mut new_generation: [Cell; GRID_WIDTH * GRID_HEIGHT] =
             [true.into(); GRID_HEIGHT * GRID_HEIGHT];
         new_generation
             .iter_mut()
             .enumerate()
             .for_each(|(idx, cell)| {
-                let cell_alive = cell.alive;
-                *cell = match self.count_neighbors(idx) {
+                let cell_alive = self.cells[idx].alive;
+                let neighbors = self.count_neighbors(idx);
+                *cell = match neighbors {
                     2 if cell_alive => Cell {
                         alive: true,
                         just_changed: false,
@@ -75,19 +76,14 @@ impl Grid {
                         alive: true,
                         just_changed: !cell_alive,
                     },
-                    _ => {
-                        death_counter += cell_alive as usize;
-                        Cell {
-                            alive: false,
-                            just_changed: cell_alive,
-                        }
-                    }
-                }
+                    _ => Cell {
+                        alive: false,
+                        just_changed: cell_alive,
+                    },
+                };
             });
 
         self.cells = new_generation;
-
-        death_counter
     }
 
     pub fn organisms(&self) -> Organisms {

--- a/src/conway/index.rs
+++ b/src/conway/index.rs
@@ -93,19 +93,31 @@ mod test {
         let neighbors = index.neighbors();
         assert_eq!(neighbors.len(), 3);
 
-        let index = Index { row: 199, col: 1 };
+        let index = Index {
+            row: GRID_HEIGHT - 1,
+            col: 1,
+        };
         let neighbors = index.neighbors();
         assert_eq!(neighbors.len(), 5);
 
-        let index = Index { row: 1, col: 199 };
+        let index = Index {
+            row: 1,
+            col: GRID_WIDTH - 1,
+        };
         let neighbors = index.neighbors();
         assert_eq!(neighbors.len(), 5);
 
-        let index = Index { row: 199, col: 199 };
+        let index = Index {
+            row: GRID_HEIGHT - 1,
+            col: GRID_WIDTH - 1,
+        };
         let neighbors = index.neighbors();
         assert_eq!(neighbors.len(), 3);
 
-        let index = Index { row: 125, col: 120 };
+        let index = Index {
+            row: GRID_HEIGHT / 2 + 2,
+            col: GRID_WIDTH / 2 + 2,
+        };
         let neighbors = index.neighbors();
         assert_eq!(neighbors.len(), 8);
     }


### PR DESCRIPTION
Fix the bug that made all cells alive after generating new generation. Add a function to get a `Vec<Iter<(u32, u32)>>` to get all the pitch and volume values from the Conway struct directly.